### PR TITLE
Merging in earlier fixes

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -32,9 +32,7 @@ CUDA_DIR := /usr/local/cuda
 
 # CUDA architecture setting: going with all of them.
 # For CUDA < 6.0, comment the *_50 lines for compatibility.
-CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
-		-gencode arch=compute_20,code=sm_21 \
-		-gencode arch=compute_30,code=sm_30 \
+CUDA_ARCH := -gencode arch=compute_30,code=sm_30 \
 		-gencode arch=compute_35,code=sm_35 \
 		-gencode arch=compute_50,code=sm_50 \
 		-gencode arch=compute_50,code=compute_50

--- a/include/caffe/common.cuh
+++ b/include/caffe/common.cuh
@@ -5,6 +5,11 @@
 
 #include <cuda.h>
 
+// dont add atomicAdd for newer versions of cuda ie 7+
+// https://stackoverflow.com/questions/39274472/error-function-atomicadddouble-double-has-already-been-defined
+ #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
+
+ #else
 // CUDA: atomicAdd is not defined for doubles
 static __inline__ __device__ double atomicAdd(double *address, double val) {
   unsigned long long int* address_as_ull = (unsigned long long int*)address;
@@ -17,5 +22,5 @@ static __inline__ __device__ double atomicAdd(double *address, double val) {
   } while (assumed != old);
   return __longlong_as_double(old);
 }
-
+ #endif
 #endif


### PR DESCRIPTION
-fix to deal with continuing training after .solverstate and .caffemodel have been moved to a different directory
-removing compute_20 and compute_21 cause they are deprecated in cuda8 and cause compilation failure in cuda 9 BVLC#5141
-added compiler directive to NOT include atomicAdd if using cuda >= 600 cause it is already defined
